### PR TITLE
Add the `metaProperties` configuration parameter

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -14,4 +14,11 @@
 
 package common
 
-const MetadataCosmosDBForNoSQLTable = "cosmos-nosql.table"
+const (
+	// KeyID is the mandatory key for each database item.
+	KeyID = "id"
+	// TestEnvNameURI is a key for connection uri pointed to an Azure Cosmos DB for NoSQL instance.
+	TestEnvNameURI = "COSMOS_NOSQL_URI"
+	// TestEnvNamePrimaryKey is a key for authentication with Azure Cosmos DB.
+	TestEnvNamePrimaryKey = "COSMOS_NOSQL_PRIMARY_KEY"
+)

--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,6 @@ const (
 	KeyContainer = "container"
 	// KeyPartitionValue is the config name for a partitionValue field.
 	KeyPartitionValue = "partitionValue"
-	// KeyKeys is the config name for a keys field.
-	KeyKeys = "keys"
 )
 
 // Config contains common source and destination configurable values.
@@ -41,6 +39,4 @@ type Config struct {
 	Container string `json:"container" validate:"required"`
 	// The logical partition key value.
 	PartitionValue string `json:"partitionValue" validate:"required"`
-	// Comma-separated list of key names to build the sdk.Record.Key.
-	Keys []string `json:"keys"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,6 @@ func TestConfig_Parse_success(t *testing.T) {
 			KeyDatabase:       "database_id",
 			KeyContainer:      "container_it",
 			KeyPartitionValue: "partVal_test",
-			KeyKeys:           "id,name,created_at",
 		}
 		want = Config{
 			URI:            "https://localhost:8081",
@@ -39,7 +38,6 @@ func TestConfig_Parse_success(t *testing.T) {
 			Database:       "database_id",
 			Container:      "container_it",
 			PartitionValue: "partVal_test",
-			Keys:           []string{"id", "name", "created_at"},
 		}
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/conduitio/conduit-connector-protocol v0.4.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,9 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=

--- a/source/config.go
+++ b/source/config.go
@@ -19,8 +19,12 @@ import "github.com/conduitio-labs/conduit-connector-cosmos-nosql/config"
 const (
 	// ConfigKeyOrderingKey is a config name for a orderingKey field.
 	ConfigKeyOrderingKey = "orderingKey"
+	// ConfigKeyKeys is the config name for a keys field.
+	ConfigKeyKeys = "keys"
 	// ConfigKeySnapshot is a config name for a snapshot field.
 	ConfigKeySnapshot = "snapshot"
+	// ConfigKeyMetaProperties is a config name for a metaProperties field.
+	ConfigKeyMetaProperties = "metaProperties"
 	// ConfigKeyBatchSize is a config name for a batchSize field.
 	ConfigKeyBatchSize = "batchSize"
 )
@@ -31,9 +35,15 @@ type Config struct {
 
 	// The name of a key that is used for ordering items.
 	OrderingKey string `json:"orderingKey" validate:"required"`
-	// Determines whether the connector will take a snapshot
+	// Comma-separated list of key names to build the sdk.Record.Key.
+	Keys []string `json:"keys"`
+	// Determines whether the connector takes a snapshot
 	// of all items before starting CDC mode.
 	Snapshot bool `json:"snapshot" default:"true"`
+	// MetaProperties whether the connector takes
+	// the next automatically generated meta-properties:
+	// "_rid", "_ts", "_self", "_etag", "_attachments".
+	MetaProperties bool `json:"metaProperties" default:"false"`
 	// The size of an element batch.
 	BatchSize uint `json:"batchSize" validate:"gt=0,lt=100001" default:"1000"`
 }

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -26,14 +26,18 @@ func TestConfig_ParseSource_success(t *testing.T) {
 
 	var (
 		raw = map[string]string{
-			ConfigKeyOrderingKey: "id",
-			ConfigKeySnapshot:    "false",
-			ConfigKeyBatchSize:   "5000",
+			ConfigKeyOrderingKey:    "id",
+			ConfigKeyKeys:           "name,created_at",
+			ConfigKeySnapshot:       "false",
+			ConfigKeyMetaProperties: "true",
+			ConfigKeyBatchSize:      "5000",
 		}
 		want = Config{
-			OrderingKey: "id",
-			Snapshot:    false,
-			BatchSize:   5000,
+			OrderingKey:    "id",
+			Keys:           []string{"name", "created_at"},
+			Snapshot:       false,
+			MetaProperties: true,
+			BatchSize:      5000,
 		}
 	)
 

--- a/source/mock/source.go
+++ b/source/mock/source.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	conduit_connector_sdk "github.com/conduitio/conduit-connector-sdk"
+	sdk "github.com/conduitio/conduit-connector-sdk"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -51,10 +51,10 @@ func (mr *MockIteratorMockRecorder) HasNext(arg0 interface{}) *gomock.Call {
 }
 
 // Next mocks base method.
-func (m *MockIterator) Next() (conduit_connector_sdk.Record, error) {
+func (m *MockIterator) Next() (sdk.Record, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next")
-	ret0, _ := ret[0].(conduit_connector_sdk.Record)
+	ret0, _ := ret[0].(sdk.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/source/source.go
+++ b/source/source.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/conduitio-labs/conduit-connector-cosmos-nosql/common"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
@@ -53,9 +54,9 @@ func (s *Source) Configure(ctx context.Context, raw map[string]string) error {
 		return fmt.Errorf("parse source config: %w", err)
 	}
 
-	// if there is no keys - use the orderingKey as a record key
+	// if there is no keys - use the 'id' as a record key
 	if len(s.config.Keys) == 0 {
-		s.config.Keys = []string{s.config.OrderingKey}
+		s.config.Keys = []string{common.KeyID}
 	}
 
 	return nil

--- a/source/source_params.go
+++ b/source/source_params.go
@@ -40,6 +40,12 @@ func (Config) Parameters() map[string]sdk.Parameter {
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},
+		"metaProperties": {
+			Default:     "false",
+			Description: "metaProperties whether the connector takes the next automatically generated meta-properties: \"_rid\", \"_ts\", \"_self\", \"_etag\", \"_attachments\".",
+			Type:        sdk.ParameterTypeBool,
+			Validations: []sdk.Validation{},
+		},
 		"orderingKey": {
 			Default:     "",
 			Description: "The name of a key that is used for ordering items.",
@@ -66,7 +72,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"snapshot": {
 			Default:     "true",
-			Description: "Determines whether the connector will take a snapshot of all items before starting CDC mode.",
+			Description: "Determines whether the connector takes a snapshot of all items before starting CDC mode.",
 			Type:        sdk.ParameterTypeBool,
 			Validations: []sdk.Validation{},
 		},

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -41,9 +41,10 @@ func TestSource_Configure_success(t *testing.T) {
 			config.KeyDatabase:       "database_id",
 			config.KeyContainer:      "container_it",
 			config.KeyPartitionValue: "partVal_test",
-			config.KeyKeys:           "id,name,created_at",
 			ConfigKeyOrderingKey:     "id",
+			ConfigKeyKeys:            "name,created_at",
 			ConfigKeySnapshot:        "false",
+			ConfigKeyMetaProperties:  "true",
 			ConfigKeyBatchSize:       "5000",
 		}
 		want = Config{
@@ -53,11 +54,12 @@ func TestSource_Configure_success(t *testing.T) {
 				Database:       "database_id",
 				Container:      "container_it",
 				PartitionValue: "partVal_test",
-				Keys:           []string{"id", "name", "created_at"},
 			},
-			OrderingKey: "id",
-			Snapshot:    false,
-			BatchSize:   5000,
+			OrderingKey:    "id",
+			Keys:           []string{"name", "created_at"},
+			Snapshot:       false,
+			MetaProperties: true,
+			BatchSize:      5000,
 		}
 	)
 


### PR DESCRIPTION
### Description

This pull request contains next changes:
1. move the config parameter `keys` from the general configuration to the source one;
2. add another source boolean parameter `metaProperties` (if it's `true` - removes all auto-generated meta properties from the payload, by default is `false`);
3. update configuration unit-tests;
4. move common constants to the common package;
5. add check of the payload to a source integration test.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-cosmos-nosql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.